### PR TITLE
Fix missing definition of `current_line` variable

### DIFF
--- a/ftplugin/python_yapf.vim
+++ b/ftplugin/python_yapf.vim
@@ -37,11 +37,12 @@ if !exists("Yapf(...)")
         endif
 
         let execmdline=yapf_cmd . " " . yapf_style . " " . l:args
-		" save current cursor position
-		let current_cursor = getpos(".")
+        let current_line = line('.')
+        " save current cursor position
+        let current_cursor = getpos(".")
         silent execute "0,$!" . execmdline
-		" restore cursor
-		call setpos('.', current_cursor)
+        " restore cursor
+        call setpos('.', current_cursor)
         if v:shell_error != 0
             " Shell command failed, so open a new buffer with error text
             execute 'normal! gg"ayG'


### PR DESCRIPTION
When `yapf` returns a non-zero code, the plugin fails due to missing `current_line` variable. I think it was accidentally removed, so I brought it back. Also fixed some indentation.